### PR TITLE
Fixed timeline navigation

### DIFF
--- a/src/presentation/common/timeline_navigation_chart/draggable_handle/anchor/index.js
+++ b/src/presentation/common/timeline_navigation_chart/draggable_handle/anchor/index.js
@@ -19,7 +19,6 @@ export default class DraggableHandler extends Component {
         handle='.dragabbleHandlerAnchor .handler'
         defaultPosition={{x: this.props.defaultPosition, y: 0}}
         position={null}
-        onStart={this.handleStart}
         onDrag={this.onDrag.bind(this)}
         onStop={this.onDragEnd.bind(this)}>
         <div className='dragabbleHandlerAnchor'>

--- a/src/presentation/common/timeline_navigation_chart/draggable_handle/index.js
+++ b/src/presentation/common/timeline_navigation_chart/draggable_handle/index.js
@@ -4,16 +4,18 @@ import './styles.css'
 
 import Anchor from './anchor'
 
+const SPACING_FOR_ANCHOR_END_POSITION = 40
+const HANDLER_WIDTH = 24
+
 export default class DraggableHandler extends Component {
   constructor (props) {
     super(props)
     this.state = {
       containerX: 0,
-      width: 150,
+      width: props.initialWidth,
       translateY: 0
     }
   }
-
   onLeftAnchorDrag (x) {
     this.setState({ width: this.state.width - x, translateY: this.state.translateY + x })
   }
@@ -33,11 +35,12 @@ export default class DraggableHandler extends Component {
   }
 
   render () {
+    const { containerX, width, translateY } = this.state
     return (
       <Draggable
         bounds={{
-          left: this.state.translateY * -1,
-          right: this.props.endPosition - this.state.width - this.state.translateY
+          left: translateY * -1,
+          right: this.props.endPosition - width - translateY
         }}
         axis='x'
         handle='.draggableHandlerDraggableSurface'
@@ -48,22 +51,23 @@ export default class DraggableHandler extends Component {
           <div
             className='draggableHandlerDraggableSurface'
             style={{
-              width: this.state.width,
-              transform: `translate(${this.state.translateY}px, 0)`
+              width: width,
+              transform: `translate(${translateY}px, 0)`
             }}
           />
           <Anchor
             left
-            startPosition={this.state.containerX * -1}
+            startPosition={containerX * -1}
+            endPosition={translateY + width - SPACING_FOR_ANCHOR_END_POSITION}
             defaultPosition={-12}
             onDrag={this.onLeftAnchorDrag.bind(this)}
             onDragEnd={this.onDrag.bind(this)}
           />
           <Anchor
             right
-            locked={this.props.endPosition - this.state.containerX === this.state.width + this.state.translateY}
-            endPosition={this.props.endPosition - this.state.containerX}
-            defaultPosition={140}
+            startPosition={SPACING_FOR_ANCHOR_END_POSITION + translateY}
+            endPosition={this.props.endPosition - containerX}
+            defaultPosition={this.state.width - (HANDLER_WIDTH / 2)}
             onDrag={this.onRightAnchorDrag.bind(this)}
             onDragEnd={this.onDrag.bind(this)}
           />

--- a/src/presentation/common/timeline_navigation_chart/index.js
+++ b/src/presentation/common/timeline_navigation_chart/index.js
@@ -16,6 +16,7 @@ export default class TimelineNavigationChart extends Component {
   componentDidMount () {
     this.setState({ elementWidth: this.container.offsetWidth })
   }
+
   onRangeChange ({ start, end }) {
     this.props.onRangeChange({
       start: start / (this.container.offsetWidth + CHART_PADDING),
@@ -28,10 +29,13 @@ export default class TimelineNavigationChart extends Component {
       <div className='timelineNavigationChart'>
         <div className='wrapper' ref={ref => { this.container = ref }}>
           <div className='handler'>
-            <DraggableHandler
-              endPosition={this.state.elementWidth}
-              onRangeChange={this.onRangeChange.bind(this)}
-            />
+            { this.container &&
+              <DraggableHandler
+                initialWidth={this.container.offsetWidth + CHART_PADDING}
+                endPosition={this.state.elementWidth}
+                onRangeChange={this.onRangeChange.bind(this)}
+              />
+            }
           </div>
           <LineChart
             height={20}

--- a/src/redux/reading/sagas/perform.js
+++ b/src/redux/reading/sagas/perform.js
@@ -1,4 +1,5 @@
 import { call, put } from 'redux-saga/effects'
+import moment from 'moment'
 
 import {
   fetchRoutineReadingsFailure,
@@ -11,7 +12,10 @@ import { addAlert } from '../../alert/actions'
 export function * performFetchRoutineReadings (httpService, { routine }) {
   try {
     const response = yield call([httpService, 'getRoutineReadings'], routine)
-    yield put(fetchRoutineReadingsSuccess(routine, response.data.data))
+    const readings = response.data.data.sort((firstReading, secondReading) =>
+      moment(firstReading.insertedAt) - moment(secondReading.insertedAt)
+    )
+    yield put(fetchRoutineReadingsSuccess(routine, readings))
   } catch (error) {
     yield put(fetchRoutineReadingsFailure(error))
   }


### PR DESCRIPTION
### Description
1. The navigation timeline now starts at the full length of the experiment

<img width="1604" alt="captura de pantalla 2018-02-13 a la s 13 05 34" src="https://user-images.githubusercontent.com/11901408/36159872-977bda2c-10be-11e8-8bd9-f0ed30226055.png">

2. The timeline anchors are restricted to a minimum value (no negative scrolling).

<img width="173" alt="captura de pantalla 2018-02-13 a la s 13 05 49" src="https://user-images.githubusercontent.com/11901408/36159894-9facdb2e-10be-11e8-9648-9dede15a6e5b.png">

3. Removed locked anchor styles when dragging to the end

<img width="129" alt="captura de pantalla 2018-02-13 a la s 13 07 08" src="https://user-images.githubusercontent.com/11901408/36159975-d62c2b8c-10be-11e8-8c52-db6e83653089.png">

4. Readings are sorted by the insertedAt attribute after they are fetched from the server.